### PR TITLE
Block owner deletion until all child resources are gone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 # Image URL to use all building/pushing image targets
 IMG ?= crossplane/templating-controller
-VERSION ?= "0.2.0"
+VERSION ?= "v0.2.1"
 
 all: test docker-build
 

--- a/pkg/resource/api.go
+++ b/pkg/resource/api.go
@@ -48,7 +48,9 @@ func NewOwnerReferenceAdder() OwnerReferenceAdder {
 type OwnerReferenceAdder struct{}
 
 func (lo OwnerReferenceAdder) Patch(cr ParentResource, list []ChildResource) ([]ChildResource, error) {
-	ref := meta.ReferenceTo(cr, cr.GroupVersionKind())
+	ref := meta.AsOwner(meta.ReferenceTo(cr, cr.GroupVersionKind()))
+	trueVal := true
+	ref.BlockOwnerDeletion = &trueVal
 	for _, o := range list {
 		// TODO(muvaf): Provider kind resources are special in the sense that
 		// their deletion should be blocked until all resources provisioned with
@@ -60,7 +62,7 @@ func (lo OwnerReferenceAdder) Patch(cr ParentResource, list []ChildResource) ([]
 		if isProvider(o) {
 			continue
 		}
-		meta.AddOwnerReference(o, meta.AsOwner(ref))
+		meta.AddOwnerReference(o, ref)
 	}
 	return list, nil
 }

--- a/pkg/resource/fake/fake.go
+++ b/pkg/resource/fake/fake.go
@@ -63,8 +63,10 @@ func WithLabels(a map[string]string) MockResourceOption {
 
 func WithOwnerReferenceTo(o metav1.Object, gvk schema.GroupVersionKind) MockResourceOption {
 	return func(r *MockResource) {
-		ref := meta.ReferenceTo(o, gvk)
-		meta.AddOwnerReference(r, meta.AsOwner(ref))
+		ref := meta.AsOwner(meta.ReferenceTo(o, gvk))
+		trueVal := true
+		ref.BlockOwnerDeletion = &trueVal
+		meta.AddOwnerReference(r, ref)
 	}
 }
 


### PR DESCRIPTION
Right now, CR instance disappears the moment it receives a deletion request. However, the upstream consumers of the CRDs want to know when to delete the credentials secret, which is when everything is deleted completely, but they do not have a way of telling that unless they traverse many CRD apis. This change allows them to have a logic like `if the CR is gone, then the secret can be deleted`.

I've tested this manually.

NOTE: This feature only works if the deletion policy is `foreground` and the default policy of `kubectl delete` is `background`. See details here https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#foreground-cascading-deletion