### PR TITLE
pipelines: add initial builds

### DIFF
--- a/Jenkinsfile.branch
+++ b/Jenkinsfile.branch
@@ -1,0 +1,9 @@
+// Load a library dynamically. For more detail, see:
+// https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
+library identifier: 'crossplane-cicd@master', retriever: modernSCM(
+  [$class: 'GitSCMSource',
+   remote: 'https://github.com/crossplane/cicd',
+   credentialsId: 'github-upbound-jenkins'])
+
+// This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.
+runStackBranchPipeline()

--- a/Jenkinsfile.continuous
+++ b/Jenkinsfile.continuous
@@ -1,0 +1,43 @@
+// The continuous pipeline is used to build and publish new versions of the stack when changes are merged into
+// the master branch.
+pipeline {
+    agent { label 'upbound-gce' }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    // Checks for unprocessed changes in the repo once per day
+    // 'H' allows Jenkins to choose the time to balance the load
+    triggers {
+        pollSCM('H H * * *')
+    }
+
+    environment {
+        DOCKER = credentials('dockerhub-upboundci')
+    }
+
+    stages {
+        stage('Publish Release') {
+
+            steps {
+                // The build step turns this into a "dirty" environment from the perspective of `git describe`,
+                // so we set the version once at the beginning and use it for both the build and publish steps.
+
+                sh """VERSION=\$( git describe --tags --dirty --always )
+                      VERSION=\${VERSION} make docker-build
+                      VERSION=\${VERSION} make docker-push
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                deleteDir()
+            }
+        }
+    }
+}

--- a/Jenkinsfile.publish
+++ b/Jenkinsfile.publish
@@ -1,0 +1,41 @@
+// The publish pipeline is used to publish a single tagged image version of the stack.
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'version', defaultValue: '', description: 'The version you are publishing. For example: v0.4.0. If left unspecified, the build will generate one for you.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        DOCKER = credentials('dockerhub-upboundci')
+    }
+
+    stages {
+        stage('Promote Release') {
+
+            steps {
+                // The build step turns this into a "dirty" environment from the perspective of `git describe`,
+                // so we set the version once at the beginning and use it for both the build and publish steps.
+
+                sh """VERSION=${params.version}
+                      VERSION=\${VERSION:-\$( git describe --tags --dirty --always )}
+                      VERSION=\${VERSION} make docker-build
+                      VERSION=\${VERSION} make docker-push
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                deleteDir()
+            }
+        }
+    }
+}

--- a/Jenkinsfile.tag
+++ b/Jenkinsfile.tag
@@ -1,0 +1,9 @@
+// Load a library dynamically. For more detail, see:
+// https://jenkins.io/doc/book/pipeline/shared-libraries/#defining-declarative-pipelines
+library identifier: 'crossplane-cicd@master', retriever: modernSCM(
+  [$class: 'GitSCMSource',
+   remote: 'https://github.com/crossplane/cicd',
+   credentialsId: 'github-upbound-jenkins'])
+
+// This is the name of a file declared in vars/{{fileName}}.groovy in the library repository.
+runStackTagPipeline()


### PR DESCRIPTION
This adds a set of pipeline builds with the same names as the template
stack pattern we've been using. Some of the pipelines are even using the
same code.

## Testing

* The shared pipelines have been tested by other projects
* I have not tested the specifics of the project-specific pipelines yet

## Other work

* [x] Create jobs in Jenkins by copying them from a template stack and changing the repository urls
* [x] Add a webhook to the github project settings
* [ ] Document the release process