### PR TITLE
Build pipelines: Add existing pipelines by copying existing ones

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,155 @@
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        booleanParam(defaultValue: true, description: 'Execute pipeline?', name: 'shouldBuild')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        RUNNING_IN_CI = 'true'
+        REPOSITORY_NAME = "${env.GIT_URL.tokenize('/')[3].split('\\.')[0]}"
+        REPOSITORY_OWNER = "${env.GIT_URL.tokenize('/')[2]}"
+        DOCKER = credentials('dockerhub-upboundci')
+        AWS = credentials('aws-upbound-bot')
+        GITHUB_UPBOUND_BOT = credentials('github-upbound-jenkins')
+        CODECOV_TOKEN = credentials('codecov-provider-gcp')
+    }
+
+    stages {
+
+        stage('Prepare') {
+            steps {
+                script {
+                    if (env.CHANGE_ID != null) {
+                        def json = sh (script: "curl -s https://api.github.com/repos/crossplane/provider-gcp/pulls/${env.CHANGE_ID}", returnStdout: true).trim()
+                        def body = evaluateJson(json,'${json.body}')
+                        if (body.contains("[skip ci]")) {
+                            echo ("'[skip ci]' spotted in PR body text.")
+                            env.shouldBuild = "false"
+                        }
+                    }
+                }
+                sh 'git config --global user.name "upbound-bot"'
+                sh 'echo "machine github.com login upbound-bot password $GITHUB_UPBOUND_BOT" > ~/.netrc'
+            }
+        }
+
+        stage('Build'){
+            when {
+                expression {
+                    return env.shouldBuild != "false"
+                }
+            }
+            steps {
+                sh './build/run make check-diff'
+                sh './build/run make vendor.check'
+                sh './build/run make -j\$(nproc) build.all'
+            }
+            post {
+                always {
+                    archiveArtifacts "_output/lint/**/*"
+                }
+            }
+        }
+
+        stage('Unit Tests') {
+            when {
+                expression {
+                    return env.shouldBuild != "false"
+                }
+            }
+            steps {
+                sh './build/run make -j\$(nproc) test'
+                sh './build/run make -j\$(nproc) cobertura'
+            }
+            post {
+                always {
+                    archiveArtifacts "_output/tests/**/*"
+                    junit "_output/tests/**/unit-tests.xml"
+                    cobertura coberturaReportFile: '_output/tests/**/cobertura-coverage.xml',
+                            classCoverageTargets: '50, 0, 0',
+                            conditionalCoverageTargets: '70, 0, 0',
+                            lineCoverageTargets: '40, 0, 0',
+                            methodCoverageTargets: '30, 0, 0',
+                            packageCoverageTargets: '80, 0, 0',
+                            autoUpdateHealth: false,
+                            autoUpdateStability: false,
+                            enableNewApi: false,
+                            failUnhealthy: false,
+                            failUnstable: false,
+                            maxNumberOfBuilds: 0,
+                            onlyStable: false,
+                            sourceEncoding: 'ASCII',
+                            zoomCoverageChart: false
+                }
+            }
+        }
+
+        stage("Integration Tests"){
+            when {
+                expression {
+                    return env.shouldBuild != "false"
+                }
+            }
+            steps {
+                sh './build/run make -j\$(nproc) e2e'
+            }
+        }
+        
+        stage('Publish Coverage to Codecov') {
+            when {
+                expression {
+                    return env.shouldBuild != "false"
+                }
+            }
+            steps {
+                script {
+                    sh 'curl -s https://codecov.io/bash | bash -s -- -c -f _output/tests/**/coverage.txt -F unittests'
+                }
+            }
+        }
+
+        stage('Publish') {
+            when {
+                expression {
+                    return env.shouldBuild != "false"
+                }
+            }
+            steps {
+                sh 'docker login -u="${DOCKER_USR}" -p="${DOCKER_PSW}"'
+                sh "./build/run make -j\$(nproc) publish BRANCH_NAME=${BRANCH_NAME} AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW} GIT_API_TOKEN=${GITHUB_UPBOUND_BOT}"
+                script {
+                    if (BRANCH_NAME == 'master') {
+                        lock('promote-job') {
+                            sh "./build/run make -j\$(nproc) promote BRANCH_NAME=master CHANNEL=master AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                sh 'make -j\$(nproc) clean'
+                sh 'make -j\$(nproc) prune PRUNE_HOURS=48 PRUNE_KEEP=48'
+                sh 'docker images'
+                deleteDir()
+            }
+        }
+    }
+}
+
+@NonCPS
+def evaluateJson(String json, String gpath){
+    // parse json
+    def ojson = new groovy.json.JsonSlurper().parseText(json)
+    // evaluate gpath as a gstring template where $json is a parsed json parameter
+    return new groovy.text.GStringTemplateEngine().createTemplate(gpath).make(json:ojson).toString()
+}

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -1,0 +1,39 @@
+String cron_string = BRANCH_NAME == "master" ? "0 22 * * *" : ""
+
+pipeline {
+    agent { label 'upbound-gce' }
+
+    triggers { cron(cron_string) }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        GCP_SA = credentials('inttests-sa')
+        KUBE_SECRET = credentials('inttests-kubeconfig')
+    }
+
+    stages {
+        stage('Integration Tests') {
+            steps {
+                sh '''
+                set +x
+                cp $KUBE_SECRET kubeconfig.yaml
+                cp $GCP_SA sa.json
+                '''
+                sh "./build/run make -j\$(nproc) go-integration"
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                sh 'make -j\$(nproc) clean'
+                deleteDir()
+            }
+        }
+    }
+}

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -1,0 +1,37 @@
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'version', defaultValue: '', description: 'The version you are releasing, for example v0.4.0')
+        string(name: 'channel', defaultValue: 'alpha', description: 'Channel you are promoting the given version to, for example alpha.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        DOCKER = credentials('dockerhub-upboundci')
+        AWS = credentials('aws-upbound-bot')
+    }
+
+    stages {
+        stage('Promote Release') {
+
+            steps {
+                sh 'docker login -u="${DOCKER_USR}" -p="${DOCKER_PSW}"'
+                sh "./build/run make -j\$(nproc) promote BRANCH_NAME=${BRANCH_NAME} VERSION=${params.version} CHANNEL=${params.channel} AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW}"
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                sh 'make -j\$(nproc) clean'
+                deleteDir()
+            }
+        }
+    }
+}

--- a/Jenkinsfile.tag
+++ b/Jenkinsfile.tag
@@ -1,0 +1,42 @@
+pipeline {
+    agent { label 'upbound-gce' }
+
+    parameters {
+        string(name: 'version', defaultValue: '', description: 'The version you are releasing, for example v0.4.0')
+        string(name: 'commit', defaultValue: '', description: 'Optional commit hash for this release, for example 56b65dba917e50132b0a540ae6ff4c5bbfda2db6. If empty the latest commit hash will be used.')
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        GITHUB_UPBOUND_BOT = credentials('github-upbound-jenkins')
+    }
+
+    stages {
+
+        stage('Prepare') {
+            steps {
+                 // github credentials are not setup to push over https in jenkins. add the github token to the url
+                sh "git config remote.origin.url https://${GITHUB_UPBOUND_BOT_USR}:${GITHUB_UPBOUND_BOT_PSW}@\$(git config --get remote.origin.url | sed -e 's/https:\\/\\///')"
+                sh 'git config user.name "upbound-bot"'
+                sh 'git config user.email "info@crossplane.io"'
+                sh 'echo "machine github.com login upbound-bot password $GITHUB_UPBOUND_BOT" > ~/.netrc'
+            }
+        }
+
+        stage('Tag Release') {
+            steps {
+                sh "./build/run make -j\$(nproc) tag VERSION=${params.version} COMMIT_HASH=${params.commit}"
+            }
+        }
+    }
+
+    post {
+        always {
+            deleteDir()
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,13 @@ fallthrough: submodules
 	@echo Initial setup complete. Running make again . . .
 	@make
 
+# Generate a coverage report for cobertura applying exclusions on
+# - generated file
+cobertura:
+	@cat $(GO_TEST_OUTPUT)/coverage.txt | \
+		grep -v zz_generated.deepcopy | \
+		$(GOCOVER_COBERTURA) > $(GO_TEST_OUTPUT)/cobertura-coverage.xml
+
 generate: go.generate
 
 # Ensure a PR is ready for review.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,7 @@
+# Release process
+
+This repo follows the [release process described
+here](https://github.com/crossplane/crossplane/blob/master/docs/release/release-process.md).
+Use the [templating-controller Jenkins
+pipelines](https://jenkinsci.upbound.io/job/crossplane/job/templating-controller/)
+with the instructions.


### PR DESCRIPTION
Related to crossplane/crossplane#1235

We want to have automated build and publishing pipelines for the templating controller repo. Since it's a repository for a go-based controller image, and uses the shared upbound build logic, the easiest starting point is to just copy an existing setup. In this case, we've copied the pipelines from `provider-gcp` and adapted them a little bit.

## Testing

* Here's a test of the tag job: https://jenkinsci.upbound.io/job/crossplane/job/templating-controller/job/templating-controller-tag/job/test-add-existing-pipelines/2/console . Note that it failed because it was not allowed to push to my fork, which is expected.
* Here's a test of the main build job: https://jenkinsci.upbound.io/job/crossplane/job/templating-controller/job/templating-controller/job/add-existing-pipelines/2/console . This mostly shows that the job can go all the way through its steps without failing.
* The first time we use the pipelines after merge will also be a bit of a test, so we'll want to keep an eye on it when we use it for the first time. In testing we exercised most of the pipeline path, but stopped short of publishing an image to the templating-controller docker repo.