### PR TITLE
Run templating-controller as non-root

### DIFF
--- a/cluster/images/templating-controller/Dockerfile
+++ b/cluster/images/templating-controller/Dockerfile
@@ -6,4 +6,5 @@ ARG TINI_VERSION
 
 ADD templating-controller /usr/local/bin/
 EXPOSE 8080
+USER 1001
 ENTRYPOINT ["templating-controller"]


### PR DESCRIPTION
This update the templating-controller to run as a non-root user as the Crossplane stack manager will reject containers that attempt to run as root per crossplane/crossplane#1444.

This has been tested with the following steps:
1. Modify `templating-controller` Dockerfile
2. `make build` /  `docker tag <build> crossplane/templating-controller:local` / `kind load docker-image crossplane/templating-controller:local`
3. Modified `stack-gcp-sample` to reference `crossplane/templating-controller:local` in its [behavior.yaml](https://github.com/crossplane/stack-gcp-sample/blob/7690dd232faf1c889e70f8eafad8c9581e9aa749/.registry/behavior.yaml#L8)
4. Modified `stack-gcp-sample` own [Dockerfile](https://github.com/crossplane/stack-gcp-sample/blob/7690dd232faf1c889e70f8eafad8c9581e9aa749/Dockerfile#L7) to add `USER 1001`
5. Started the Crossplane `stack-manager` on my fork of https://github.com/crossplane/crossplane/pull/1444
6. Created a `ClusterStackInstall` for `stack-gcp-sample` and saw controller provisioned successfully
7. Created a `GCPSample` and saw it create the desired resources with no errors in controller logs

I also tried two other scenarios, both which were expected to fail and did:
1. Run `stack-gcp-sample` with `templating-controller:v0.3.0-rc`
2. Run `stack-gcp-sample` with the new build of `templating-controller`, but its own `Dockerfile` not modified

These scenarios demonstrate that all template stacks will require having their `behavior.yaml` and `Dockerfile` updated.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>