### PR TITLE
Incorporate stacks -> packages module name change

### DIFF
--- a/cmd/templating-controller/main.go
+++ b/cmd/templating-controller/main.go
@@ -36,8 +36,8 @@ import (
 	kustomizeapi "sigs.k8s.io/kustomize/api/types"
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
-	"github.com/crossplane/crossplane/apis/stacks"
-	"github.com/crossplane/crossplane/apis/stacks/v1alpha1"
+	"github.com/crossplane/crossplane/apis/packages"
+	"github.com/crossplane/crossplane/apis/packages/v1alpha1"
 
 	"github.com/crossplane/templating-controller/pkg/operations/helm3"
 	"github.com/crossplane/templating-controller/pkg/operations/kustomize"
@@ -75,7 +75,7 @@ func main() {
 	gvk := schema.FromAPIVersionAndKind(sd.Spec.Behavior.CRD.APIVersion, sd.Spec.Behavior.CRD.Kind)
 
 	kingpin.FatalIfError(clientgoscheme.AddToScheme(scheme), "could not register client-go scheme")
-	kingpin.FatalIfError(stacks.AddToScheme(scheme), "could not register stacks group scheme")
+	kingpin.FatalIfError(packages.AddToScheme(scheme), "could not register stacks group scheme")
 
 	mgrOptions := ctrl.Options{
 		Scheme: scheme,

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/crossplane/templating-controller
 go 1.13
 
 require (
-	github.com/crossplane/crossplane v0.10.0
-	github.com/crossplane/crossplane-runtime v0.8.0
+	github.com/crossplane/crossplane v0.11.0-rc.0.20200513205252-806cd9602557
+	github.com/crossplane/crossplane-runtime v0.8.1-0.20200512204508-290de7349949
 	github.com/google/go-cmp v0.4.0
 	github.com/pkg/errors v0.9.1
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2

--- a/go.sum
+++ b/go.sum
@@ -139,11 +139,11 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
-github.com/crossplane/crossplane v0.10.0 h1:D/p5DAY6OA0G/fNpZwNJuyI5Bnn1V3IHUXph2AL+ttw=
-github.com/crossplane/crossplane v0.10.0/go.mod h1:02lcxMXOp3Amy/hTOsSIVJxtyql6dTgdEIntkMkblnw=
+github.com/crossplane/crossplane v0.11.0-rc.0.20200513205252-806cd9602557 h1:aQZHAQ8zmXuK6SidxL5fd6gFLKgztqAf0JyZ0yfS4Sg=
+github.com/crossplane/crossplane v0.11.0-rc.0.20200513205252-806cd9602557/go.mod h1:5+nGoBOqlkIcCTy9vZXGNz0si3En/MDdMuRUhIWddV4=
 github.com/crossplane/crossplane-runtime v0.7.1-0.20200421211018-be37c50cc2ab/go.mod h1:e12p4X6dbtqd9GOnph78Epd6aezyvmcMM1+6aQy3VzY=
-github.com/crossplane/crossplane-runtime v0.8.0 h1:IBm5LWVeqB2BjHpkykURHY0PSozXWfIXk7LfWtr27wY=
-github.com/crossplane/crossplane-runtime v0.8.0/go.mod h1:gNY/21MLBaz5KNP7hmfXbBXp8reYRbwY5B/97Kp4tgM=
+github.com/crossplane/crossplane-runtime v0.8.1-0.20200512204508-290de7349949 h1:m2LpYaLAwSJK5dF893bNC3wnMJqoF2y5ruZz37l6dDU=
+github.com/crossplane/crossplane-runtime v0.8.1-0.20200512204508-290de7349949/go.mod h1:gNY/21MLBaz5KNP7hmfXbBXp8reYRbwY5B/97Kp4tgM=
 github.com/crossplane/crossplane-tools v0.0.0-20200219001116-bb8b2ce46330 h1:zxdYGQnQbfyZSnRbKUJ16x5lRzkUTbH+uumVq03ijYo=
 github.com/crossplane/crossplane-tools v0.0.0-20200219001116-bb8b2ce46330/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
 github.com/crossplane/crossplane-tools v0.0.0-20200412230150-efd0edd4565b h1:BqGODFDKcq4hd8RZeWmh8BsjfHS0eAtGWMLtT74rsG8=

--- a/pkg/operations/kustomize/api.go
+++ b/pkg/operations/kustomize/api.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/yaml"
 
-	"github.com/crossplane/crossplane/apis/stacks/v1alpha1"
+	"github.com/crossplane/crossplane/apis/packages/v1alpha1"
 
 	"github.com/crossplane/templating-controller/pkg/resource"
 )

--- a/pkg/operations/kustomize/kustomize_test.go
+++ b/pkg/operations/kustomize/kustomize_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
-	"github.com/crossplane/crossplane/apis/stacks/v1alpha1"
+	"github.com/crossplane/crossplane/apis/packages/v1alpha1"
 
 	"github.com/crossplane/templating-controller/pkg/resource"
 )

--- a/pkg/templating/api.go
+++ b/pkg/templating/api.go
@@ -30,7 +30,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	rresource "github.com/crossplane/crossplane-runtime/pkg/resource"
-	"github.com/crossplane/crossplane/pkg/stacks"
+	"github.com/crossplane/crossplane/pkg/packages"
 
 	"github.com/crossplane/templating-controller/pkg/resource"
 )
@@ -152,7 +152,7 @@ type ParentLabelSetAdder struct{}
 // Patch patches the child resources with information in resource.ParentResource.
 func (lo ParentLabelSetAdder) Patch(cr resource.ParentResource, list []resource.ChildResource) ([]resource.ChildResource, error) {
 	for _, o := range list {
-		meta.AddLabels(o, stacks.ParentLabels(cr))
+		meta.AddLabels(o, packages.ParentLabels(cr))
 	}
 	return list, nil
 }

--- a/pkg/templating/api_test.go
+++ b/pkg/templating/api_test.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
-	"github.com/crossplane/crossplane/pkg/stacks"
+	"github.com/crossplane/crossplane/pkg/packages"
 
 	"github.com/crossplane/templating-controller/pkg/resource"
 	"github.com/crossplane/templating-controller/pkg/resource/fake"
@@ -256,8 +256,8 @@ func TestParentLabelSetAdder(t *testing.T) {
 			},
 			want: want{
 				result: []resource.ChildResource{
-					fake.NewMockResource(fake.WithAdditionalLabels(stacks.ParentLabels(parent))),
-					fake.NewMockResource(fake.WithAdditionalLabels(stacks.ParentLabels(parent))),
+					fake.NewMockResource(fake.WithAdditionalLabels(packages.ParentLabels(parent))),
+					fake.NewMockResource(fake.WithAdditionalLabels(packages.ParentLabels(parent))),
 				},
 			},
 		},


### PR DESCRIPTION
Incorporate stacks -> packages module name change. This is required because templating-controller fetches `StackDefinition` once and its group changed from `stacks.crossplane.io` to `packages.crossplane.io`.

Tested manually together with https://github.com/crossplane/crossplane/pull/1510