### PR TITLE
Pin crossplane and crossplane-runtime ahead of cutting release-0.4 branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/crossplane/templating-controller
 go 1.13
 
 require (
-	github.com/crossplane/crossplane v0.11.0-rc.0.20200513205252-806cd9602557
-	github.com/crossplane/crossplane-runtime v0.8.1-0.20200512204508-290de7349949
+	github.com/crossplane/crossplane v0.11.0
+	github.com/crossplane/crossplane-runtime v0.9.0
 	github.com/google/go-cmp v0.4.0
 	github.com/pkg/errors v0.9.1
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2

--- a/go.sum
+++ b/go.sum
@@ -139,11 +139,11 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
-github.com/crossplane/crossplane v0.11.0-rc.0.20200513205252-806cd9602557 h1:aQZHAQ8zmXuK6SidxL5fd6gFLKgztqAf0JyZ0yfS4Sg=
-github.com/crossplane/crossplane v0.11.0-rc.0.20200513205252-806cd9602557/go.mod h1:5+nGoBOqlkIcCTy9vZXGNz0si3En/MDdMuRUhIWddV4=
+github.com/crossplane/crossplane v0.11.0 h1:uye4oDt8Pz7JoGBI0qtPuUHENDxLu0LIxhX+gyTUySM=
+github.com/crossplane/crossplane v0.11.0/go.mod h1:+AH83k737iABb8jUKyo8zML73JZZioeybuShGyAtbkg=
 github.com/crossplane/crossplane-runtime v0.7.1-0.20200421211018-be37c50cc2ab/go.mod h1:e12p4X6dbtqd9GOnph78Epd6aezyvmcMM1+6aQy3VzY=
-github.com/crossplane/crossplane-runtime v0.8.1-0.20200512204508-290de7349949 h1:m2LpYaLAwSJK5dF893bNC3wnMJqoF2y5ruZz37l6dDU=
-github.com/crossplane/crossplane-runtime v0.8.1-0.20200512204508-290de7349949/go.mod h1:gNY/21MLBaz5KNP7hmfXbBXp8reYRbwY5B/97Kp4tgM=
+github.com/crossplane/crossplane-runtime v0.9.0 h1:K6/tLhXKzhsEUUddTvEWWnQLLrawWyw1ptNK7NBDpDU=
+github.com/crossplane/crossplane-runtime v0.9.0/go.mod h1:gNY/21MLBaz5KNP7hmfXbBXp8reYRbwY5B/97Kp4tgM=
 github.com/crossplane/crossplane-tools v0.0.0-20200219001116-bb8b2ce46330 h1:zxdYGQnQbfyZSnRbKUJ16x5lRzkUTbH+uumVq03ijYo=
 github.com/crossplane/crossplane-tools v0.0.0-20200219001116-bb8b2ce46330/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
 github.com/crossplane/crossplane-tools v0.0.0-20200412230150-efd0edd4565b h1:BqGODFDKcq4hd8RZeWmh8BsjfHS0eAtGWMLtT74rsG8=


### PR DESCRIPTION
Pins crossplane to `v0.11.0` and crossplane-runtime to `v0.9.0`.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>