### PR TITLE
Deletion calls is done via Foreground deletion policy

### DIFF
--- a/pkg/templating/api.go
+++ b/pkg/templating/api.go
@@ -225,5 +225,6 @@ func (d *APIOrderedDeleter) deleteIfControllable(ctx context.Context, obj, contr
 	if metav1.GetControllerOf(obj) != nil && !metav1.IsControlledBy(obj, controller) {
 		return errors.New(errNotController)
 	}
-	return errors.Wrap(client.IgnoreNotFound(d.kube.Delete(ctx, obj)), errDeleteChildResource)
+	err := client.IgnoreNotFound(d.kube.Delete(ctx, obj, client.PropagationPolicy(metav1.DeletePropagationForeground)))
+	return errors.Wrap(err, errDeleteChildResource)
 }


### PR DESCRIPTION
The need for this change is that `KubernetesApplication` resource in core Crossplane assumes that its deletion done via `Foreground` deletion policy, which is not default, and relies on that for deletion of KARs. Since we have a requirement to delete all resources we deployed in the remote cluster, the reason of https://github.com/crossplane/templating-controller/issues/17 , the deletion should be done via `Foreground` policy. More context in https://crossplane.slack.com/archives/CEF5N8X08/p1590155317252500

This doesn't have any effect on other resources (in wp app or sample stack) as of now since no other resource is owner of others.

However, in the long run, it's safer to use `Background` policy since it's the default.